### PR TITLE
add price to schedule form & log & mailview

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -113,6 +113,6 @@ class SchedulesController < ApplicationController
   private
 
   def schedule_params
-    params.require(:schedule).permit(:title, :notification_period, :next_notification)
+    params.require(:schedule).permit(:title, :notification_period, :next_notification, :price)
   end
 end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -8,6 +8,7 @@ class Schedule < ApplicationRecord
   validates :title, presence: true
   validates :notification_period, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :next_notification, presence: true
+  validates :price, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
   validate :next_notification_must_be_future
 
   enum status: { disabled: 0, enabled: 1 }, _prefix: true

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -20,6 +20,7 @@
           <td><%= schedule.notification_period %></td>
           <td><%= schedule.next_notification.strftime("%Y/%-m/%-d") %></td>
           <td><%= schedule.after_next_notification.strftime("%Y/%-m/%-d") %></td>
+          <td><%= schedule.price.nil? ? "無し" : schedule.price %></td>
           <td><%= schedule.status_enabled? ? "有効" : "無効" %></td>
           <td>
             <%= link_to '編集', edit_schedule_path(schedule), class: "btn btn-primary" %>

--- a/app/views/admin/logs/index.html.erb
+++ b/app/views/admin/logs/index.html.erb
@@ -31,6 +31,7 @@
       <th>送信時間</th>
       <th>作成日時</th>
       <th>更新日時</th>
+      <th>予算（価格）</th>
     </tr>
   </thead>
   <tbody>
@@ -43,6 +44,7 @@
         <td><%= log.send_time.strftime("%Y/%m/%d %H:%M") %></td>
         <td><%= log.created_at.strftime("%Y/%m/%d %H:%M") %></td>
         <td><%= log.updated_at.strftime("%Y/%m/%d %H:%M") %></td>
+        <td><%= log.price.nil? ? 'なし': log.price %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -18,6 +18,7 @@
         <th>周期</th>
         <th>次回予定日</th>
         <th>次々回予定日</th>
+        <th>予算（価格）</th>
         <th>状態</th>
         <th>操作</th>
         <th>テスト</th>
@@ -31,6 +32,7 @@
             <td><%= schedule.notification_period %></td>
             <td><%= schedule.next_notification.strftime("%Y/%-m/%-d") %></td>
             <td><%= schedule.after_next_notification.strftime("%Y/%-m/%-d") %></td>
+            <td><%= schedule.price.nil? ? "無し" : schedule.price %></td>
             <td><%= schedule.status_enabled? ? "有効" : "無効" %></td>
             <td>
               <%= link_to '編集', edit_schedule_path(schedule), class: "btn btn-primary" %>
@@ -66,6 +68,7 @@
           <td><%= schedule.notification_period %></td>
           <td><%= schedule.next_notification.strftime("%Y/%-m/%-d") %></td>
           <td><%= schedule.after_next_notification.strftime("%Y/%-m/%-d") %></td>
+          <td><%= schedule.price.nil? ? "無し" : schedule.price %></td>
           <td><%= schedule.status_enabled? ? "有効" : "無効" %></td>
         </tr>
       <% end %>

--- a/app/views/shared/_schedule_form.html.erb
+++ b/app/views/shared/_schedule_form.html.erb
@@ -16,6 +16,11 @@
       <%= f.datetime_local_field :next_notification, value: Time.zone.today.since(7.days) %>
     </div>
   
+    <div class="form-item">
+      <%= f.label :price, '予算（価格）' %>
+      <%= f.number_field :price %>
+    </div>
+
     <%= f.submit '作成' %>
   <% end %>
 </div>

--- a/app/views/user_mailer/send_magic_link_schedule.html.erb
+++ b/app/views/user_mailer/send_magic_link_schedule.html.erb
@@ -4,3 +4,7 @@
 周期　　　　：<%= @schedule.notification_period %>
 次回予定日　：<%= @schedule.next_notification.to_date.strftime('%Y/%-m/%-d') %>
 次々回予定日：<%= @schedule.after_next_notification.to_date.strftime('%Y/%-m/%-d') %>
+<% unless @schedule.price.nil? %>
+  予算（価格）：<%= @schedule.price %>円
+<% end %>
+

--- a/app/views/user_mailer/send_magic_link_schedule_change.html.erb
+++ b/app/views/user_mailer/send_magic_link_schedule_change.html.erb
@@ -3,3 +3,6 @@
 周期　　　　：<%= @schedule.notification_period %>
 次回予定日　：<%= @schedule.next_notification.to_date.strftime('%Y/%-m/%-d') %>
 次々回予定日：<%= @schedule.after_next_notification.to_date.strftime('%Y/%-m/%-d') %>
+<% unless @schedule.price.nil? %>
+  予算（価格）：<%= @schedule.price %>円
+<% end %>

--- a/app/views/user_mailer/send_schedule_change_notification.html.erb
+++ b/app/views/user_mailer/send_schedule_change_notification.html.erb
@@ -4,4 +4,7 @@
 <ul>
   <li>予定日　　：<%= @schedule.next_notification.to_date.strftime('%Y/%-m/%-d') %></li>
   <li>次回予定日：<%= @schedule.after_next_notification.to_date.strftime('%Y/%-m/%-d') %></li>
+  <% unless @schedule.price.nil? %>
+    <li>予算（価格）：<%= @schedule.price %>円</li>
+  <% end %>
 </ul>

--- a/app/views/user_mailer/send_schedule_notifications.html.erb
+++ b/app/views/user_mailer/send_schedule_notifications.html.erb
@@ -5,6 +5,9 @@
     <li>予定名　　：<%= schedule.title %></li>
     <li>予定日　　：<%= schedule.next_notification.to_date.strftime('%Y/%-m/%-d') %></li>
     <li>次回予定日：<%= schedule.after_next_notification.to_date.strftime('%Y/%-m/%-d') %></li>
+    <% unless schedule.price.nil? %>
+      <li>予算（価格）：<%= schedule.price %>円</li>
+    <% end %>
     <% if @user.user_setting.need_check_done %>
       <li><%= link_to '完了する', complete_schedule_url(schedule, token: schedule.done_token), method: :post %></li>
     <% end %>

--- a/db/migrate/20250418043952_add_price_to_schedules.rb
+++ b/db/migrate/20250418043952_add_price_to_schedules.rb
@@ -1,0 +1,5 @@
+class AddPriceToSchedules < ActiveRecord::Migration[7.1]
+  def change
+    add_column :schedules, :price, :integer
+  end
+end

--- a/db/migrate/20250418044152_add_price_to_notification_logs.rb
+++ b/db/migrate/20250418044152_add_price_to_notification_logs.rb
@@ -1,0 +1,5 @@
+class AddPriceToNotificationLogs < ActiveRecord::Migration[7.1]
+  def change
+    add_column :notification_logs, :price, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_06_162849) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_18_044152) do
   create_table "notification_logs", force: :cascade do |t|
     t.integer "schedule_id", null: false
     t.datetime "send_time"
     t.boolean "is_snooze"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "price"
     t.index ["schedule_id"], name: "index_notification_logs_on_schedule_id"
   end
 
@@ -32,6 +33,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_06_162849) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "done_token"
+    t.integer "price"
     t.index ["creator_type", "creator_id"], name: "index_schedules_on_creator"
   end
 

--- a/lib/tasks/schedule_mailer.rake
+++ b/lib/tasks/schedule_mailer.rake
@@ -18,6 +18,7 @@ namespace :mailer do
             NotificationLog.create!(
               schedule_id: schedule.id,
               send_time: schedule.next_notification,
+              price: schedule.price,
               is_snooze: true
             )
   
@@ -29,6 +30,7 @@ namespace :mailer do
             NotificationLog.create!(
               schedule_id: schedule.id,
               send_time: schedule.next_notification,
+              price: schedule.price,
               is_snooze: false
             )
 

--- a/spec/system/user/schedule_management_spec.rb
+++ b/spec/system/user/schedule_management_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "一般ユーザーによる予定管理", type: :system do
     fill_in "予定名", with: "新しい予定"
     fill_in "周期", with: 3
     fill_in "次回予定日", with: Date.today + 1
+    fill_in "予算（価格）", with: 100
     click_button "作成"
 
     expect(page).to have_content("予定を作成しました。")


### PR DESCRIPTION
## 概要
 - 予約の項目に”予算（価格）”を追加しました。

## 変更内容
 - schedulesとnotification_logsテーブルにinteger型のpriceカラムを追加。
 - 予定の作成フォームに”予算（価格）”を追加、予定の一覧とログにも表示されるように変更。
 - user_mailerの各ビューに”予算（価格）”の表示を追加。
 - specのテストを加筆し予定作成のテスト対象に追加。

## 補足
 - priceのバリデーションは数値の0以上とし、価格の存在しない予定もあるためnilのままの作成も許可します。
 - nilで作成した場合は予定一覧などの表示は”なし”、メールの本文では表示されないようにしました。
