### PR TITLE
add model&controller application_settings

### DIFF
--- a/app/controllers/admin/application_settings_controller.rb
+++ b/app/controllers/admin/application_settings_controller.rb
@@ -1,0 +1,23 @@
+class Admin::ApplicationSettingsController < ApplicationController
+  def edit
+    @setting = ApplicationSetting.instance
+  end
+
+  def update
+    @setting = ApplicationSetting.instance
+    if @setting.update(setting_params)
+      system("bundle exec whenever --update-crontab --set environment=production")
+      flash[:notice] = '設定を変更しました。'
+      redirect_to edit_admin_application_setting_path
+    else
+      flash.now[:alert] = '設定の変更に失敗しました。'
+      render :edit
+    end
+  end
+
+  private
+
+  def setting_params
+    params.require(:application_setting).permit(:base_notification_hour, :base_notification_minute, :base_pre_notification_hour, :base_pre_notification_minute)
+  end
+end

--- a/app/helpers/admin/application_settings_helper.rb
+++ b/app/helpers/admin/application_settings_helper.rb
@@ -1,0 +1,2 @@
+module Admin::ApplicationSettingsHelper
+end

--- a/app/models/application_setting.rb
+++ b/app/models/application_setting.rb
@@ -1,0 +1,10 @@
+class ApplicationSetting < ApplicationRecord
+  def self.instance
+    first_or_create!(
+      base_notification_hour: 0,
+      base_notification_minute: 0,
+      base_pre_notification_hour: 0,
+      base_pre_notification_minute: 0
+    )
+  end
+end

--- a/app/views/admin/application_settings/edit.html.erb
+++ b/app/views/admin/application_settings/edit.html.erb
@@ -1,0 +1,30 @@
+<h1>アプリケーション設定</h1>
+
+<%= form_with model: @setting, url: admin_application_setting_path, local: true do |f| %>
+  <table>
+    <thead>
+      <tr>
+        <th></th>
+        <th>項目</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <tr>
+        <td>通知時間</td>
+        <td>
+          <%= f.number_field :base_notification_hour %>：
+          <%= f.number_field :base_notification_minute %>
+        </td>
+      </tr>
+      <tr>
+        <td>事前通知</td>
+        <td>
+          <%= f.number_field :base_pre_notification_hour %>：
+          <%= f.number_field :base_pre_notification_minute %>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <%= f.submit '更新' %>
+<% end %>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,5 +1,7 @@
 <h1>管理画面　予定一覧</h1>
 
+<%= link_to '環境設定', edit_admin_application_setting_path %>
+
 <% @users.each do |user| %>
   <h2><%= user.email %> ( <%= user.name.present? ? user.name : "no_name" %> )</h2>
   <table class="schedule-table">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
     post 'sessions' => 'sessions#create'
     delete 'sessions' => 'sessions#destroy', as: :logout
     resources 'logs', only: [:index]
+    resource :application_setting, only: [:edit, :update]
   end
 
   resource :user_setting, only: %i[show update]

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,27 +1,13 @@
-# Use this file to easily define all of your cron jobs.
-#
-# It's helpful, but not entirely necessary to understand cron before proceeding.
-# http://en.wikipedia.org/wiki/Cron
-
-# Example:
-#
-# set :output, "/path/to/my/cron_log.log"
-#
-# every 2.hours do
-#   command "/usr/bin/some_great_command"
-#   runner "MyModel.some_method"
-#   rake "some:great:rake:task"
-# end
-#
-# every 4.days do
-#   runner "AnotherModel.prune_old_records"
-# end
-
-# Learn more: http://github.com/javan/whenever
+require File.expand_path("../config/environment", __dir__)
 
 set :output, "#{path}/log/cron.log"
 env :PATH, ENV['PATH']
 
-every 1.day, at: '0:00' do
+setting = ApplicationSetting.first
+
+hour = setting&.base_notification_hour || 0
+minute = setting&.base_notification_minute || 0
+
+every 1.day, at: "#{format('%02d', hour)}:#{format('%02d', minute)}" do
   rake 'mailer:send_schedule_notifications', environment: 'production'
 end

--- a/db/migrate/20250427061507_create_application_settings.rb
+++ b/db/migrate/20250427061507_create_application_settings.rb
@@ -1,0 +1,12 @@
+class CreateApplicationSettings < ActiveRecord::Migration[7.1]
+  def change
+    create_table :application_settings do |t|
+      t.integer :base_notification_hour
+      t.integer :base_notification_minute
+      t.integer :base_pre_notification_hour
+      t.integer :base_pre_notification_minute
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_19_092506) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_27_061507) do
+  create_table "application_settings", force: :cascade do |t|
+    t.integer "base_notification_hour"
+    t.integer "base_notification_minute"
+    t.integer "base_pre_notification_hour"
+    t.integer "base_pre_notification_minute"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "notification_logs", force: :cascade do |t|
     t.integer "schedule_id", null: false
     t.datetime "send_time"

--- a/spec/factories/application_settings.rb
+++ b/spec/factories/application_settings.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :application_setting do
+    base_notification_hour { 1 }
+    base_notification_minute { 1 }
+    base_pre_notification_hour { 1 }
+    base_pre_notification_minute { 1 }
+  end
+end

--- a/spec/helpers/admin/application_settings_helper_spec.rb
+++ b/spec/helpers/admin/application_settings_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Admin::ApplicationSettingsHelper. For example:
+#
+# describe Admin::ApplicationSettingsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Admin::ApplicationSettingsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/application_setting_spec.rb
+++ b/spec/models/application_setting_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationSetting, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/admin/application_settings_spec.rb
+++ b/spec/requests/admin/application_settings_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "Admin::ApplicationSettings", type: :request do
+  describe "GET /edit" do
+    it "returns http success" do
+      get "/admin/application_settings/edit"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/admin/application_settings/edit.html.erb_spec.rb
+++ b/spec/views/admin/application_settings/edit.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "application_settings/edit.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
 - 管理画面に通知時間を設定する機能を追加

## 変更内容
 - application_settingsテーブルを作成。
 - 管理画面にアプリケーション設定の画面を追加、コントローラーを作成。
 - cronで定期実行する時間をアプリケーション設定を参照するように変更、変更時に更新を実行。

## 補足
 - 事前予定通知の時刻設定は作成のみ、実際のアクション等は未作成（別issue）。
