### PR TITLE
modify routes schedule complete

### DIFF
--- a/app/controllers/user_settings_controller.rb
+++ b/app/controllers/user_settings_controller.rb
@@ -5,9 +5,20 @@ class UserSettingsController < ApplicationController
     @settings = @user.user_setting
   end
 
-  def update
+  def check_done
     @settings = current_user.user_setting || current_user.build_user_setting
-    if @settings.update(settings_params)
+    if @settings.update(check_done_params)
+      flash[:notice] = '設定を変更しました。'
+      redirect_to user_setting_path
+    else
+      flash[:alert] = '設定を変更できませんでした。'
+      render :show, status: :unprocessable_entity
+    end
+  end
+
+  def notification_time
+    @settings = current_user.user_setting || current_user.build_user_setting
+    if @settings.update(time_params)
       flash[:notice] = '設定を変更しました。'
       redirect_to user_setting_path
     else
@@ -18,7 +29,11 @@ class UserSettingsController < ApplicationController
 
   private
 
-  def settings_params
-    params.require(:user_setting).permit(:need_check_done, :notification_hour, :notification_minute, :pre_notification)
+  def check_done_params
+    params.require(:user_setting).permit(:need_check_done)
+  end
+
+  def time_params
+    params.require(:user_setting).permit(:notification_hour, :notification_minute, :pre_notification)
   end
 end

--- a/app/views/user_mailer/send_schedule_notifications.html.erb
+++ b/app/views/user_mailer/send_schedule_notifications.html.erb
@@ -9,7 +9,7 @@
       <li>予算（価格）：<%= schedule.price %>円</li>
     <% end %>
     <% if @user.user_setting.need_check_done %>
-      <li><%= link_to '完了する', complete_schedule_url(schedule, token: schedule.done_token), method: :post %></li>
+      <%= link_to '完了する', complete_schedule_url(schedule, token: schedule.done_token) %>
     <% end %>
   <% end %>
 </ul>

--- a/app/views/user_settings/show.html.erb
+++ b/app/views/user_settings/show.html.erb
@@ -1,50 +1,60 @@
 <div class="container">
   <h2>設定項目</h2>
   <div class="border-bottom mt-3 mb-3"></div>
-</div>
 
-<div class="container mb-4">
-  <div class="d-flex align-items-center">
-    <div class="d-flex flex-column" >
-      <h3>メールアドレスを変更する。</h3>
-      <p>- 登録メールアドレスに変更リンクが送信されます。</p>
-    </div>
-    <div class="ms-4">
-      <%= link_to "変更", edit_email_path, class: 'btn btn-light ms-3' %> 
+  <div class="container mb-4">
+    <div class="d-flex align-items-center">
+      <div class="d-flex flex-column" >
+        <h3>メールアドレスを変更する。</h3>
+        <p class="ms-3">- 登録メールアドレスに変更リンクが送信されます。</p>
+      </div>
+      <div class="ms-4">
+        <%= link_to "変更", edit_email_path, class: 'btn btn-success ms-3' %> 
+      </div>
     </div>
   </div>
-</div>
 
 
-<div class="container mb-4">
-  <div class="border-bottom mt-3 mb-3"></div>
-  <h3>通知</h3>
-  <%= form_with model: @settings, url: user_setting_path, scope: :user_setting, method: :patch, local: true do |f| %>
-  <div class="d-flex align-items-end">
-    <div class="d-flex flex-column" >
-      <div class="mt-2">
-        <%= f.label :need_check_done, '要予定完了チェック ' %>
-        <%= f.check_box :need_check_done %>
+  <div class="container mt-4 mb-4">
+    <h3 class="mt-4">予定通知</h3>
+    <%= form_with model: @settings, url: check_done_user_setting_path, scope: :user_setting, method: :patch, local: true do |f| %>
+      <div class="d-flex ms-3">
+        <div class="d-flex align-items-center " >
+          <div class="mt-2">
+            <%= f.label :need_check_done, '要完了チェック '  %>
+            <%= f.check_box :need_check_done  %>
+          </div>
+          <div class="d-flex ms-4 mt-2">
+            <%= f.submit 'チェック設定を更新', class: 'btn btn-success' %>
+          </div>
+        </div>
       </div>
-    
-      <div class="mt-2">
-        <%= f.label :notification_hour, '通知予定 時：' %>
-        <%= f.number_field :notification_hour, min: 0, max: 23 %>
+      <p class="d-flex ms-4 mb-0" >※通知メールに完了リンクを追加します。</p>
+      <p class="d-flex ms-4 mb-0" >　リンクにアクセスして完了しない限り、通知を繰り返します。</p>
+    <% end %>
+
+    <h3 class="mt-4">通知時刻</h3>
+    <%= form_with model: @settings, url: notification_time_user_setting_path, scope: :user_setting, method: :patch, local: true do |f| %>
+      <div class="d-flex align-items-end ms-3">
+        <div class="d-flex flex-column" >
+          <div class="mt-2">
+            <%= f.label :notification_hour, '通知予定 時：' %>
+            <%= f.number_field :notification_hour, min: 0, max: 23 %>
+
+            <%= f.label :notification_minute, '：' %>
+            <%= f.number_field :notification_minute, min: 0, max: 59 %>
+          </div>
+        
+          <div class="mt-2">
+            <%= f.label :pre_notification, '事前予定通知：' %>
+            <%= f.datetime_field :pre_notification %>
+          </div>
+        
+        </div>
+        <div class="d-flex ms-4 mt-2">
+          <%= f.submit '通知時刻を更新', class: 'btn btn-success' %>
+        </div>
       </div>
-    
-      <div class="mt-2">
-        <%= f.label :notification_minute, '通知予定 分：' %>
-        <%= f.number_field :notification_minute, min: 0, max: 59 %>
-      </div>
-    
-      <div class="mt-2">
-        <%= f.label :pre_notification, '事前予定通知：' %>
-        <%= f.datetime_field :pre_notification %>
-      </div>
-    
-    </div>
-    <div class="d-flex ms-4 mt-2">
-      <%= f.submit '更新', class: 'btn btn-success' %>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,10 +46,13 @@ Rails.application.routes.draw do
     resource :application_setting, only: [:edit, :update]
   end
 
-  resource :user_setting, only: %i[show update]
+  resource :user_setting, only: %i[show] do
+    patch :check_done
+    patch :notification_time
+  end
 
   resources :schedules, only: %i[index create edit update] do
-    post :complete, on: :member
+    get :complete, on: :member
   end
   get 'schedule/:id/archive' => 'schedules#archive', as: :archive_schedule
   patch 'schedule/:id/archive' => 'schedules#archive_complete', as: :archive_complete_schedule


### PR DESCRIPTION
## 概要
 - 予定の完了チェックの修正（schedulesコントローラーのcompleteアクション）

## 変更内容
 - ルート設定がユーザー側から送れないpostメソッドになっていたため、getメソッドで処理出来るように修正しました。
 - ユーザー設定画面が分かりにくかったため、完了チェックの欄と時間設定の欄とを分離させました。

## 補足
 - 
