### PR TITLE
add preset_schedules

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -6,3 +6,4 @@ import "Chart.bundle"
 import "./loading.js"
 import Rails from "@rails/ujs"
 Rails.start()
+import "preset"

--- a/app/javascript/preset.js
+++ b/app/javascript/preset.js
@@ -1,0 +1,42 @@
+import { schedulePresets } from "./presets/schedule_presets";
+
+console.log("preset.js loaded");
+console.log("schedulePresets is:", schedulePresets);
+
+document.addEventListener("DOMContentLoaded", () => {
+  const select = document.getElementById('presetSelect');
+  
+  const defaultOption = document.createElement("option");
+  defaultOption.value = "";
+  defaultOption.textContent = "-- 選択して下さい --";
+  select.appendChild(defaultOption);
+
+  for (const key in schedulePresets) {
+    const option = document.createElement("option");
+    option.value = key;
+    option.textContent = schedulePresets[key].name;
+    select.appendChild(option);
+  }
+
+  const titleField = document.getElementById('schedule_title');
+  const periodField = document.getElementById('schedule_period');
+  const priceField = document.getElementById('schedule_price');
+  const nextNotificationField = document.getElementById('schedule_next_notification');
+
+  select.addEventListener('change', (e) => {
+    const preset = schedulePresets[e.target.value];
+    if (preset) {
+      titleField.value = preset.title;
+      periodField.value = preset.period;
+      priceField.value = preset.price;
+
+      const nextDate = new Date();
+      nextDate.setDate(nextDate.getDate() + preset.period);
+      const year = nextDate.getFullYear();
+      const month = String(nextDate.getMonth() + 1).padStart(2, "0");
+      const day = String(nextDate.getDate()).padStart(2, "0");
+      
+      nextNotificationField.value = `${year}-${month}-${day}T00:00`;
+    }
+  });
+});

--- a/app/javascript/presets/schedule_presets.js
+++ b/app/javascript/presets/schedule_presets.js
@@ -1,0 +1,56 @@
+export const schedulePresets = {
+  item1: {
+    name: '購入 | 7日毎 ',
+    title: '購入：',
+    period: 7,
+    price: 0
+  },
+  item2: {
+    name: '購入 | 14日毎 ',
+    title: '購入：',
+    period: 14,
+    price: 0
+  },
+  item01: {
+    name: '--------',
+    title: '無題',
+    period: 1,
+    price: 0
+  },
+  item3: {
+    name: '作業 | 10日毎 ',
+    title: '作業：',
+    period: 10,
+    price: 0
+  },
+  item4: {
+    name: '作業 | 15日毎 ',
+    title: '作業：',
+    period: 15,
+    price: 0
+  },
+  item5: {
+    name: '作業 | 60日毎 ',
+    title: '作業：',
+    period: 60,
+    price: 0
+  },
+  item6: {
+    name: '作業 | 180日毎 ',
+    title: '作業：',
+    period: 180,
+    price: 0
+  },
+  item02: {
+    name: '--------',
+    title: '無題',
+    period: 1,
+    price: 0
+  },
+  item7: {
+    name: '振込 | 30日毎 ',
+    title: '振込；',
+    period: 30,
+    price: 0
+  }
+}

--- a/app/views/shared/_schedule_form.html.erb
+++ b/app/views/shared/_schedule_form.html.erb
@@ -1,31 +1,39 @@
 <div class="container">
   <div class="schedule_form">
     <h2>予定作成</h2>
+
+    <div class="row m-2">
+      <div class="d-flex justify-content-around align-items-center gap-3">
+        <label for="presetSelect" style="width: 10%;">プリセット</label>
+        <select id="presetSelect" class="form-select">
+        </select>
+      </div>
+    </div>
     <%= form_with model: @schedule, url: schedules_path, local: true do |f| %>
       <div class="row m-2">
-        <div class="form-item col-5">
+        <div class="form-item col-6">
           <%= f.label :title, "予定名" %>
-          <%= f.text_field :title, size: "40", value: 'test' %>
+          <%= f.text_field :title, size: "40", value: 'test', id: 'schedule_title' %>
         </div>
       
         <div class="form-item col-5">
           <%= f.label :notification_period, '周期' %>
-          <%= f.number_field :notification_period, size: "20", value: 7 %> 日毎
+          <%= f.number_field :notification_period, size: "20", value: 7, id: 'schedule_period' %> 日毎
         </div>
       </div>
       
       <div class="row m-2">
-        <div class="col-5">
+        <div class="col-6">
           <div class="form-item">
             <%= f.label :next_notification, '次回予定日' %>
-            <%= f.datetime_local_field :next_notification, value: Time.zone.today.since(7.days) %>
+            <%= f.datetime_local_field :next_notification, value: Time.zone.today.since(7.days), id: 'schedule_next_notification' %>
           </div>
         </div>
         
         <div class="col-5">
           <div class="form-item">
             <%= f.label :price, '予算（価格）' %>
-            <%= f.number_field :price %>
+            <%= f.number_field :price, id: 'schedule_price'  %>
           </div>
         </div>
       </div>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -11,3 +11,4 @@ pin_all_from 'app/javascript/controllers', under: 'controllers'
 pin 'chartkick', to: 'chartkick.js'
 pin 'Chart.bundle', to: 'Chart.bundle.js'
 pin '@rails/ujs', to: '@rails--ujs.js' # @7.1.3
+pin 'preset', to: 'preset.js'


### PR DESCRIPTION
## 概要
 - スケジュール作成補助機能追加

## 変更内容
 - 予定作成フォームにプリセットを用意しました。
・予定の種類（購入、作業、振込）、周期（7, 10, 14, 15, 30, 60, 180）など、入力を少しでも省けるようにしました。

## 補足
 - プリセットは専用のjsに分離させ、追加し易くしています。
 - 価格も設定できますが、手動で設定した方が良いため”0”としています。
