### PR TITLE
remove column notification_test from schedule index, and clean up values

### DIFF
--- a/app/controllers/shared_lists_controller.rb
+++ b/app/controllers/shared_lists_controller.rb
@@ -12,7 +12,7 @@ class SharedListsController < ApplicationController
 
   def edit
     @shared_list = SharedList.find(params[:id])
-    @shared_user = SharedUser.new(email: 'shared_user@example.com')
+    @shared_user = SharedUser.new()
     @user_schedules = current_user.schedules.where.not(id: @shared_list.schedule_ids)
   end
 

--- a/app/views/shared/_schedule_form.html.erb
+++ b/app/views/shared/_schedule_form.html.erb
@@ -13,7 +13,7 @@
       <div class="row m-2">
         <div class="form-item col-6">
           <%= f.label :title, "予定名" %>
-          <%= f.text_field :title, size: "40", value: 'test', id: 'schedule_title' %>
+          <%= f.text_field :title, size: "40", id: 'schedule_title' %>
         </div>
       
         <div class="form-item col-5">

--- a/app/views/shared/_schedule_table.html.erb
+++ b/app/views/shared/_schedule_table.html.erb
@@ -16,7 +16,6 @@
           <th>予算（価格）</th>
           <th>状態</th>
           <th>操作</th>
-          <th>テスト</th>
         </tr>
       </thead>
       <tbody>
@@ -33,10 +32,7 @@
                 <%= link_to '編集', edit_schedule_path(schedule), class: "btn btn-primary" %>
                 <%= link_to '削除', archive_schedule_path(schedule), class: "btn btn-danger" %>
               </td>
-              <td>
-              <%= link_to "通知テスト", notification_schedule_path(schedule), class: "btn btn-info" %>
-            </td>
-          </tr>
+            </tr>
           <% end %>
         <% end %>
       </tbody>


### PR DESCRIPTION
## 概要
 - 開発用データの整理2

## 変更内容
 - 予定一覧ページから開発用に置いていた予定通知テストの列を削除しました。
 - 消し忘れで共有リストページに残っていた開発補助用のvalueを削除しました。

## 補足
 - 予定作成フォームで連続作成しようとしたときに2度目は埋め込まれないので改善の余地あり（非同期通信の問題）
