### PR TITLE
Line login singup

### DIFF
--- a/app/controllers/line_logins_controller.rb
+++ b/app/controllers/line_logins_controller.rb
@@ -12,7 +12,7 @@ class LineLoginsController < ApplicationController
       client_id: ENV.fetch('LINE_CHANNEL_ID', nil),
       redirect_uri: ENV.fetch('LINE_REDIRECT_URI', nil),
       state: state,
-      scope: 'profile openid'
+      scope: 'profile openid email'
     }.to_query
     redirect_to "#{base_url}?#{query}", allow_other_host: true
   end
@@ -20,10 +20,9 @@ class LineLoginsController < ApplicationController
   def callback
     return handle_invalid_state if params[:state] != session[:line_login_state]
 
-    line_user_id = fetch_line_user_id(params[:code])
-    return handle_line_login_failure if line_user_id.blank?
-
-    user = User.find_by(line_user_id: line_user_id)
+    line_user_id, line_user_email = fetch_line_user_id_email(params[:code])
+    user = line_email_login(line_user_email, line_user_id) || User.find_by(line_user_id: line_user_id)
+    return handle_line_login_failure unless user
 
     if user
       login_user(user)
@@ -49,28 +48,41 @@ class LineLoginsController < ApplicationController
     redirect_to root_path, alert: '不正なアクセスです'
   end
 
-  def fetch_line_user_id(code)
+  def fetch_line_user_id_email(code)
     token_response = HTTParty.post('https://api.line.me/oauth2/v2.1/token', {
-                                     headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
-                                     body: {
-                                       grant_type: 'authorization_code',
-                                       code: code,
-                                       redirect_uri: ENV.fetch('LINE_REDIRECT_URI', nil),
-                                       client_id: ENV.fetch('LINE_CHANNEL_ID', nil),
-                                       client_secret: ENV.fetch('LINE_CHANNEL_SECRET', nil)
-                                     }
-                                   })
+                                    headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
+                                    body: {
+                                      grant_type: 'authorization_code',
+                                      code: code,
+                                      redirect_uri: ENV.fetch('LINE_REDIRECT_URI', nil),
+                                      client_id: ENV.fetch('LINE_CHANNEL_ID', nil),
+                                      client_secret: ENV.fetch('LINE_CHANNEL_SECRET', nil)
+                                    }
+                                  })
 
-    access_token = JSON.parse(token_response.body)['access_token']
-    return nil if access_token.blank?
+    body = JSON.parse(token_response.body)
+    access_token = body['access_token']
+    id_token = body['id_token']
+    return [nil, nil] unless access_token && id_token
 
     profile_response = HTTParty.get('https://api.line.me/v2/profile', {
                                       headers: { 'Authorization' => "Bearer #{access_token}" }
                                     })
 
-    JSON.parse(profile_response.body)['userId']
+    line_user_id = JSON.parse(profile_response.body)['userId']
+    line_user_email = JWT.decode(id_token, nil, false).first['email']
+    [line_user_id, line_user_email]
   rescue StandardError => e
     Rails.logger.warn("LINE認証エラー: #{e.message}")
-    nil
+    [nil, nil]
+  end
+
+
+  def line_email_login(line_user_email, line_user_id)
+    user = User.find_by(email: line_user_email) 
+    return nil unless user
+
+    user.update(line_user_id: line_user_id) if user.line_user_id.blank?
+    user
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,6 +19,7 @@ module ApplicationHelper
     return false if controller_name == 'password_resets'
     return false if controller_name == 'magic_links'
     return false if controller_name == 'home' && 'index'
+    return false if controller_name == 'terms' && 'show'
 
     true
   end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -27,9 +27,6 @@
       <%= link_to "Googleでログイン", google_login_path, class: "btn btn-outline-dark" %>
     </div>
     
-  <div class="m-3">
-    <button class="show-loading">test loading</button>
-  </div>
   <br><br>
 
   <p>登録がまだの方はこちら</p>


### PR DESCRIPTION
## 概要
 - 修正：LINEログインの既存アカウント紐付け

## 変更内容
 - LINEログインでメールアドレスを取得、既存アカウントがあれば紐付けるアクションが漏れていたので作成しました。

## 補足
 - その他、トップページに残っていたテスト用のローディングアニメーションボタンを削除しました。
