### PR TITLE
modify routes, avoid NameError for LetterOpenerWeb in production env

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?
+  if Rails.env.development? && defined?(LetterOpenerWeb)
+    mount LetterOpenerWeb::Engine, at: '/letter_opener'
+  end
 
   get '/google_login', to: 'google_logins#new', as: :google_login
   get '/google_login/callback', to: 'google_logins#callback', as: :google_login_callback


### PR DESCRIPTION
## 概要
 - ルート修正（letter_opener）

## 変更内容
 - routesの記述が間違っていたので修正し、letter_openerの範囲をdevelopmentに制限しました。

## 補足
 - 
